### PR TITLE
scaleFactor calculation for gradient could cause divide by zero error…

### DIFF
--- a/ColorManager.js
+++ b/ColorManager.js
@@ -73,7 +73,7 @@ var ColorManager = function(){
 
     if (colorInterpolation === 'gradient'){
       colorFunction = getGradientColor;
-      scaleFactor = (colors.length-1)/(dataLength -1);
+      scaleFactor = (colors.length-1)/(dataLength +1);
     } else {
       colorFunction = getIndexedColor;
       scaleFactor = (colors.length)/(dataLength+1);


### PR DESCRIPTION
This should fix:

https://github.com/tmroyal/Chart.HeatMap/issues/2

If the range of heatmap data isn't sufficiently large you can get divide by zero errors. Looks like maybe should be adding one here instead of subtracting.

Not sure what version of Charts.js you were basing this off off, so I didn't rebuild the whole project, just changed the main source file.